### PR TITLE
Expose container image as env variable in containers

### DIFF
--- a/charts/app-compat/Chart.yaml
+++ b/charts/app-compat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: app-compat
-version: 1.0.39
+version: 1.0.40
 maintainers:
   - name: Praveen
     email: praveen@livspace.com

--- a/charts/app-compat/templates/deployment.yaml
+++ b/charts/app-compat/templates/deployment.yaml
@@ -272,8 +272,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-	    - name: CONTAINER_IMAGE
-	        value: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            - name: CONTAINER_IMAGE
+              value: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- range $.Values.EnvVariablesFromFieldPath }}
             - name: {{ .name }}
               valueFrom:

--- a/charts/app-compat/templates/deployment.yaml
+++ b/charts/app-compat/templates/deployment.yaml
@@ -272,6 +272,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+	    - name: CONTAINER_IMAGE
+	        value: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- range $.Values.EnvVariablesFromFieldPath }}
             - name: {{ .name }}
               valueFrom:


### PR DESCRIPTION
## Description

- `render-farm-worker` pods need access to the current image in use so that the same can be passed to Kube API server for creating `render-farm-job` with the same image path. This change exposes the current image as environment variable. 