### PR TITLE
chore: ENG-22410 support comma-separated values in podLabels

### DIFF
--- a/charts/application/Chart.yaml
+++ b/charts/application/Chart.yaml
@@ -4,3 +4,9 @@ description: Generic helm chart for all kind of applications
 type: application
 version: 1.0.20
 home: https://github.com/livspaceeng/helm-charts
+maintainers:
+  - name: Praveen
+    email: praveen@livspace.com
+    url: www.livspace.com
+  - name: Ankit
+    email: ankit.a@livspace.com

--- a/charts/application/Chart.yaml
+++ b/charts/application/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: application
 description: Generic helm chart for all kind of applications
 type: application
-version: 1.0.19
+version: 1.0.20
 home: https://github.com/livspaceeng/helm-charts

--- a/charts/application/templates/_helpers.tpl
+++ b/charts/application/templates/_helpers.tpl
@@ -68,3 +68,18 @@ app: {{ include "application.name" . }}
 webapp: "true"
 {{- end }}
 {{- end }}
+
+{{/*
+podLabels renderer: accepts comma-separated values as a convenience for
+authoring multi-valued labels (e.g. `spoc: a, b` -> `spoc: "a_b"`), so that
+authors can express multiple logical values inside a single Kubernetes label
+without violating the label-value regex. Values without a comma pass through
+unchanged.
+*/}}
+{{- define "application.podLabels" -}}
+{{- $rendered := dict -}}
+{{- range $key, $value := .Values.deployment.podLabels -}}
+{{-   $_ := set $rendered $key (regexReplaceAll `\s*,\s*` (toString $value) "_") -}}
+{{- end -}}
+{{ toYaml $rendered }}
+{{- end -}}

--- a/charts/application/templates/deployment.yaml
+++ b/charts/application/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
 {{ include "application.selectorLabels" . | indent 8 }}
 {{ include "pod.systemLabels" . | indent 8 }}
 {{- if .Values.deployment.podLabels }}
-{{ toYaml .Values.deployment.podLabels | indent 8 }}
+{{ include "application.podLabels" . | indent 8 }}
 {{- end }}
 {{- if or .Values.deployment.additionalPodAnnotations .Values.deployment.fluentdConfigAnnotations }}
       annotations:

--- a/charts/application/values.yaml
+++ b/charts/application/values.yaml
@@ -91,9 +91,12 @@ deployment:
   additionalLabels:
     # key: value
 
-  # Additional label added on pod which is used in Service's Label Selector
+  # Additional label added on pod which is used in Service's Label Selector.
+  # Comma-separated values are supported and rendered as underscore-joined
+  # (e.g. `spoc: a, b` -> `spoc: "a_b"`) to satisfy Kubernetes label value rules.
   podLabels:
     # env: prod
+    # spoc: a, b
 
   # Annotations on deployments
   annotations:

--- a/charts/application/values.yaml
+++ b/charts/application/values.yaml
@@ -53,10 +53,10 @@ deployment:
     #   maxSurge: 25%
     #   maxUnavailable: 25%
 
-  #terminationGracePeriodSeconds
+  # terminationGracePeriodSeconds
   gracePeriod: 30
 
-  #container lifecycle
+  # container lifecycle
   lifecycle:
     enabled: false
     preStop:
@@ -201,7 +201,7 @@ deployment:
   image:
     repository: repository/image-name
     tag: ''
-    digest: '' # if set to a non empty value, digest takes precedence on the tag
+    digest: ''  # if set to a non empty value, digest takes precedence on the tag
     pullPolicy: IfNotPresent
   dnsConfig:
     # options:
@@ -260,7 +260,7 @@ deployment:
     port: 8080   # Port on which application is running inside container
     secretName: "openshift-oauth-proxy-tls"
     image: openshift/oauth-proxy:latest       # If you have a custom container for oauth-proxy that can be updated here
-    disableTLSArg: false # If disabled --http-address=:8081 will be used instead of --https-address=:8443 , to be used when an ingress is used for application
+    disableTLSArg: false  # If disabled --http-address=:8081 will be used instead of --https-address=:8443 , to be used when an ingress is used for application
   # Add additional containers besides init and app containers
   additionalContainers:
   # - name: sidecar-contaner
@@ -282,15 +282,15 @@ deployment:
 
   # List of ports for the primary container
   ports:
-  #- containerPort: 8080
-  #  name: http
-  #  protocol: TCP
-  #- containerPort: 8778
-  #  name: jolokia
-  #  protocol: TCP
-  #- containerPort: 8443
-  #  name: https
-  #  protocol: TCP
+  # - containerPort: 8080
+  #   name: http
+  #   protocol: TCP
+  # - containerPort: 8778
+  #   name: jolokia
+  #   protocol: TCP
+  # - containerPort: 8443
+  #   name: https
+  #   protocol: TCP
 
 
 ##########################################################
@@ -321,7 +321,7 @@ ingress:
   # Port of the service that serves pods
   servicePort: http
 
-  #Set pathType: default is ImplementationSpecific; Options: Exact, Prefix
+  # Set pathType: default is ImplementationSpecific; Options: Exact, Prefix
   pathType: ImplementationSpecific
 
   # List of host addresses to be exposed by this Ingress
@@ -356,7 +356,7 @@ ingressInternal:
   # Port of the service that serves pods
   servicePort: http
 
-  #Set pathType: default is ImplementationSpecific; Options: Exact, Prefix
+  # Set pathType: default is ImplementationSpecific; Options: Exact, Prefix
   pathType: ImplementationSpecific
 
   # List of host addresses to be exposed by this Ingress
@@ -445,9 +445,9 @@ configMap:
 sealedSecret:
   enabled: false
   additionalLabels:
-    #key: value
+    # key: value
   annotations:
-    #key: value
+    # key: value
   files:
 #  #nameSuffix of sealedSecret
 #     example:
@@ -541,14 +541,14 @@ autoscaling:
     resource:
       name: cpu
       target:
-         type: Utilization
-         averageUtilization: 60
+        type: Utilization
+        averageUtilization: 60
   - type: Resource
     resource:
       name: memory
       target:
-         type: Utilization
-         averageUtilization: 60
+        type: Utilization
+        averageUtilization: 60
 
 ##########################################################
 # Pod disruption budget - PDB


### PR DESCRIPTION
## Summary
Adds a helper so `deployment.podLabels` in the `application` chart accepts comma-separated values and renders them as underscore-joined strings. `spoc: a, b` → `spoc: "a_b"`. Values without a comma pass through unchanged, so this is fully backward-compatible with all existing services.

Jira: [ENG-22410](https://livspaceengg.atlassian.net/browse/ENG-22410)

## Problem
The `appCompat` version bundled with this repo validates every Kubernetes label value against the standard label regex `(([A-Za-z0-9][-A-Za-z0-9.]*)?[A-Za-z0-9])?` — alphanumerics, `-`, `_`, `.`, and must start/end with an alphanumeric. Commas are illegal, so authoring a multi-valued label like:

```yaml
deployment:
  podLabels:
    spoc: a, b
```

is rejected. This is a common shape when a pod belongs to multiple SPOCs / squads / owners.

## Change
- New `application.podLabels` helper in `charts/application/templates/_helpers.tpl`. Builds a transformed dict, replacing `,` (plus any surrounding whitespace) with `_` in each value, then emits via `toYaml`.
- `charts/application/templates/deployment.yaml` — the podLabels rendering site now calls the helper instead of `toYaml` directly.
- `charts/application/values.yaml` — docstring above `podLabels` documents the new convenience.

## Before / after
Input:
```yaml
deployment:
  podLabels:
    spoc: "a, b"
    env: prod
```
Renders to:
```yaml
    metadata:
      labels:
        ...
        env: prod
        spoc: a_b
```

## Test plan
- [x] `helm lint charts/application` — clean
- [x] `helm template` with comma-separated podLabels → transformed correctly (`spoc: a_b`, `complex: x_y_z`, `number: "42"`)
- [x] `helm template` regression on single-value podLabels → byte-identical to prior render (unquoted values preserved)
- [x] `helm template` with empty/absent podLabels → the outer `if` still short-circuits the block
- [ ] Beta deploy on a service that opts in to a comma-separated `podLabels` and verify `kubectl get pod -o jsonpath='{.items[0].metadata.labels}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-22410]: https://livspaceengg.atlassian.net/browse/ENG-22410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ