### PR TITLE
app-compat: add opt-in llmGatewayToken (projected SA token for LLM gateway)

### DIFF
--- a/charts/app-compat/Chart.yaml
+++ b/charts/app-compat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: app-compat
-version: 3.3.6
+version: 3.3.7
 maintainers:
   - name: Praveen
     email: praveen@livspace.com

--- a/charts/app-compat/templates/deployment.yaml
+++ b/charts/app-compat/templates/deployment.yaml
@@ -499,6 +499,11 @@ spec:
             - name: aws-dir-volume
               mountPath: /root/.aws
           {{- end }}
+          {{- if (.Values.llmGatewayToken).enabled }}
+            - name: llm-gw-token
+              mountPath: {{ .Values.llmGatewayToken.mountPath | default "/var/run/secrets/llm-gateway" }}
+              readOnly: true
+          {{- end }}
           {{- if and $hasCMVolumeExists (.Values.externalConfigMaps)}}
           {{- range $configMap := .Values.externalConfigMaps  }}
             {{- if $configMap.path  }}
@@ -545,6 +550,15 @@ spec:
         - emptyDir:
             medium: Memory
           name: gtoken-vol
+      {{- end }}
+      {{- if (.Values.llmGatewayToken).enabled }}
+        - name: llm-gw-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  audience: {{ .Values.llmGatewayToken.audience | default "apisix-llm-gateway" }}
+                  expirationSeconds: {{ .Values.llmGatewayToken.expirationSeconds | default 3600 }}
+                  path: token
       {{- end }}
       {{- if (.Values.externalConfigMaps)}}
       {{- range $item := .Values.externalConfigMaps  }}

--- a/charts/app-compat/values.yaml
+++ b/charts/app-compat/values.yaml
@@ -329,6 +329,16 @@ canary:
 
 mountGToken: false
 
+# LLM gateway (APISIX) access via a projected ServiceAccount token — Path B, no static key.
+# When enabled, mounts a short-lived, kubelet-rotated SA token that the app sends as
+# `Authorization: Bearer` to the LLM gateway. `audience` MUST match the gateway's
+# openid-connect client_id. Opt-in; default off (no effect on services that don't set it).
+llmGatewayToken:
+  enabled: false
+  audience: apisix-llm-gateway
+  mountPath: /var/run/secrets/llm-gateway
+  expirationSeconds: 3600
+
 deployment:
   image:
     repository: livcr.io/livspace/app-name


### PR DESCRIPTION
Adds an **opt-in** `llmGatewayToken.enabled` flag (default **false**) to the `app-compat` chart. When a service enables it, the chart mounts a **projected ServiceAccount token** at `/var/run/secrets/llm-gateway` (audience `apisix-llm-gateway`, kubelet-rotated, ~1h) that the app sends as `Authorization: Bearer` to the APISIX LLM gateway.

## Why
Part of **Path B** for the LLM gateway: services authenticate with their **k8s ServiceAccount** (no static key), and the gateway authorizes per-model + attributes token/cost per service. Instead of each service hand-declaring the projected-token volume in its `values.yaml`, they flip one flag:
```yaml
llmGatewayToken:
  enabled: true
```

## Safety
- **Default off** → zero change to any existing service (verified: `helm template` emits nothing unless enabled).
- Mirrors the existing `mountGToken` pattern (AWS IRSA projected token).
- Deployment template only; `audience`/`mountPath`/`expirationSeconds` overridable.

## Version
`3.3.6` → `3.3.7`. Needs a chart release to `charts.livspace.com` before consumers can pin it; then services set `llmGatewayToken.enabled: true` and drop the explicit volume block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)