### PR TITLE
app-compat 3.3.7: networkPolicy.mesh flag (Linkerd 4143 peer rules)

### DIFF
--- a/charts/app-compat/Chart.yaml
+++ b/charts/app-compat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: app-compat
-version: 3.3.6
+version: 3.3.7
 maintainers:
   - name: Praveen
     email: praveen@livspace.com

--- a/charts/app-compat/templates/networkpolicy.yaml
+++ b/charts/app-compat/templates/networkpolicy.yaml
@@ -20,7 +20,7 @@ spec:
   {{- if .Values.networkPolicy.ingress }}
   ingress:
   {{- range $rule := .Values.networkPolicy.ingress.fromApps }}
-  {{- if or $rule.httpPorts $rule.tcpPorts $rule.udpPorts }}
+  {{- if or $rule.httpPorts $rule.tcpPorts $rule.udpPorts $.Values.networkPolicy.mesh }}
   {{- $labelKey := default "app" $rule.labelKey }}
   - from:
     - podSelector:
@@ -44,13 +44,19 @@ spec:
     - port: {{ $port }}
       protocol: UDP
     {{- end }}
+    {{- if $.Values.networkPolicy.mesh }}
+    # Linkerd proxy inbound port: meshed peers connect proxy-to-proxy on 4143,
+    # so per-peer rules must allow it in addition to the app ports.
+    - port: 4143
+      protocol: TCP
+    {{- end }}
   {{- end }}
   {{- end }}
   {{- end }}
   {{- if .Values.networkPolicy.egress }}
   egress:
   {{- range $app := .Values.networkPolicy.egress.toApps }}
-  {{- if or $app.httpPorts $app.tcpPorts $app.udpPorts }}
+  {{- if or $app.httpPorts $app.tcpPorts $app.udpPorts $.Values.networkPolicy.mesh }}
   {{- $labelKey := default "app" $app.labelKey }}
   - to:
     - podSelector:
@@ -73,6 +79,12 @@ spec:
     {{- range $port := $app.udpPorts }}
     - port: {{ $port }}
       protocol: UDP
+    {{- end }}
+    {{- if $.Values.networkPolicy.mesh }}
+    # Linkerd proxy inbound port: meshed peers connect proxy-to-proxy on 4143,
+    # so per-peer rules must allow it in addition to the app ports.
+    - port: 4143
+      protocol: TCP
     {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/app-compat/values.yaml
+++ b/charts/app-compat/values.yaml
@@ -496,6 +496,11 @@ winterSoldier:
 
 networkPolicy:
   enabled: false
+  # mesh: when true, every fromApps/toApps peer rule additionally allows TCP 4143
+  # (the Linkerd proxy inbound port). Required for policies to match traffic
+  # between Linkerd-meshed pods: the wire connection is sidecar-to-sidecar on
+  # 4143, so rules listing only app ports never match meshed traffic.
+  mesh: false
   # ingress defines rules for incoming traffic to your application pods
   # ingress:
   #   fromApps:


### PR DESCRIPTION
## What

Adds `networkPolicy.mesh` (default `false`) to app-compat. When enabled, every `ingress.fromApps` / `egress.toApps` peer rule additionally allows **TCP 4143** — the Linkerd proxy inbound port — to/from that same peer.

## Why

Between Linkerd-meshed pods, the actual wire connection is sidecar→sidecar on **4143**; the app port (8080, 7030, …) exists only inside the mesh tunnel. NetworkPolicy is enforced at the wire level, so peer rules listing only app ports **never match meshed traffic** — under policy enforcement it gets dropped. This is the biggest known gap behind the gke-prod enforcement re-enablement program ([plan](https://wiki.livspace.io/doc/gke-prod-network-policy-re-enablement-plan-vi1b68THre)): ~615 meshed service pairs observed in the 5-day Hubble flow inventory communicate on 4143.

Putting 4143 in the chart (rather than appending it to every service's `httpPorts`) keeps values semantic — services declare app intent, the chart owns the wire-level mesh detail in one place.

## Safety

- Default `false`; rendered output is byte-identical unless a service sets `mesh: true` (verified with `helm template`).
- Version bump **3.3.6 → 3.3.7** (patch): existing `~3.3.6` pins pick this up automatically, which is safe because rendering is unchanged until a service opts in with `mesh: true` — no per-service version bumps needed.

## Render check

With `mesh: true` and one peer `daakiya httpPorts:[7030]`, the egress rule emits ports 7030 **and** 4143 to `app=daakiya`; the automatic DNS egress block is unchanged.